### PR TITLE
MVP for Debug Mode

### DIFF
--- a/librellog/src/ast/ast.rs
+++ b/librellog/src/ast/ast.rs
@@ -185,6 +185,33 @@ macro_rules! tm {
     };
 }
 
+#[macro_export]
+macro_rules! rel_match {
+    ($expr:expr, { $( $([$key:ident = $value:pat])+ $(| $([$key2:ident = $value2:ident])+)* => $block:expr, )* else => $default:expr }) => {
+        loop {
+            $(
+                $(
+                    let $key = $expr.get(&IStr::from(stringify!($key)));
+                )+
+                if let ( $(Some($value),)+ ) = ( $($key, )+ ) {
+                    break $block;
+                }
+
+                $(
+                    $(
+                        let $key2 = $expr.get(&IStr::from(stringify!($key2)));
+                    )+
+                    if let ( $(Some($value2),)+ ) = ( $($key2, )+ ) {
+                        break $block;
+                    }
+                )*
+            )*
+
+            break $default;
+        }
+    };
+}
+
 impl Dup for RcTm {
     fn dup(&self, duper: &mut TmDuplicator) -> Self {
         self.0.dup(duper).into()

--- a/librellog/src/ast/tm_displayer.rs
+++ b/librellog/src/ast/tm_displayer.rs
@@ -60,12 +60,12 @@ impl Indent {
 impl fmt::Display for Indent {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for _ in 0..self.offset {
-            f.write_char('·')?;
-            // f.write_char(' ')?;
+            // f.write_char('·')?;
+            f.write_char(' ')?;
         }
         for _ in 0..self.indent {
-            f.write_str("␣␣␣␣")?;
-            // f.write_str("    ")?;
+            // f.write_str("␣␣␣␣")?;
+            f.write_str("    ")?;
         }
         Ok(())
     }
@@ -157,12 +157,12 @@ impl<'tm> TmDisplayer<'tm> {
         for (sym, tm) in map {
             match (sym, tm.as_ref()) {
                 (s1, Tm::Sym(s2)) if s1 == s2 => {
-                    writeln!(f, "[{sym}]")?;
+                    write!(f, "[{sym}]")?;
                     // writeln!(f, "[{sym}")?;
                     // write!(f, "{}]", self.indent.dedented())?;
                 }
                 (s, Tm::Var(v)) if s.to_str().to_pascal_case() == v.to_str().as_ref() => {
-                    writeln!(f, "[{v}]")?;
+                    write!(f, "[{v}]")?;
                     // writeln!(f, "[{v}")?;
                     // write!(f, "{}]", self.indent.dedented())?;
                 }

--- a/librellog/src/ast/tm_displayer.rs
+++ b/librellog/src/ast/tm_displayer.rs
@@ -1,5 +1,6 @@
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter, Write};
 
+use heck::ToPascalCase;
 use rpds::Vector;
 
 use crate::{
@@ -8,36 +9,98 @@ use crate::{
     lex::tok::Tok,
 };
 
+#[derive(Clone, Default)]
 pub struct TmDisplayer<'tm> {
-    indent: usize,
     tm: Option<&'tm Tm>,
+    indent: Indent,
 }
 
-impl Default for TmDisplayer<'_> {
+#[derive(Clone, Copy)]
+/// The formula for number of spaces to show at a give level is: `self.offset +
+/// 4 * self.indent`
+struct Indent {
+    /// Used to describe indentation level.
+    indent: usize,
+    /// Used to add an additional offset (beyond indentation).
+    offset: usize,
+}
+
+impl Default for Indent {
     fn default() -> Self {
         Self {
             indent: 1,
-            tm: None,
+            offset: 0,
         }
     }
 }
 
-impl<'tm> TmDisplayer<'tm> {
-    pub fn indented(&self, tm: impl Into<Option<&'tm Tm>>) -> Self {
+impl Indent {
+    fn indented(self) -> Self {
         Self {
             indent: self.indent + 1,
-            tm: tm.into(),
+            ..self
+        }
+    }
+
+    fn dedented(self) -> Self {
+        Self {
+            indent: self.indent - 1,
+            ..self
+        }
+    }
+
+    fn offset_by(self, additional_offset: usize) -> Self {
+        Self {
+            offset: self.offset + additional_offset,
+            ..self
+        }
+    }
+}
+
+impl fmt::Display for Indent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for _ in 0..self.offset {
+            f.write_char('·')?;
+            // f.write_char(' ')?;
+        }
+        for _ in 0..self.indent {
+            f.write_str("␣␣␣␣")?;
+            // f.write_str("    ")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'tm> TmDisplayer<'tm> {
+    pub fn indented(&self, tm: &'tm Tm) -> Self {
+        Self {
+            tm: Some(tm),
+            indent: self.indent.indented(),
+        }
+    }
+
+    pub fn dedented(&self) -> Self {
+        Self {
+            indent: self.indent.dedented(),
+            ..self.clone()
+        }
+    }
+
+    pub fn indented_with_offset(&self, tm: &'tm Tm, additional_offset: usize) -> Self {
+        Self {
+            tm: Some(tm),
+            indent: self.indent.indented().offset_by(additional_offset),
         }
     }
 
     pub fn with_tm(&self, tm: &'tm Tm) -> Self {
         Self {
             tm: Some(tm),
-            ..*self
+            ..self.clone()
         }
     }
 
-    fn fmt_sym(&self, f: &mut Formatter<'_>, sym: &IStr) -> Result<(), fmt::Error> {
+    fn fmt_sym(&self, f: &mut Formatter<'_>, sym: &IStr) -> fmt::Result {
         let sym = sym.to_str();
         if !sym.is_empty()
             && !sym.contains(|c: char| !c.is_alphanumeric())
@@ -55,29 +118,71 @@ impl<'tm> TmDisplayer<'tm> {
 
     pub fn fmt_block(
         &self,
+        f: &mut fmt::Formatter,
         functor: &Tok,
         members: &Vector<RcTm>,
-        f: &mut fmt::Formatter,
-    ) -> Result<(), fmt::Error> {
+    ) -> fmt::Result {
+        const SPACE: &str = " ";
+        let functor = functor.to_string();
+
         for member in members {
             writeln!(f)?;
-            for _ in 0..self.indent {
-                f.write_str("    ")?;
-            }
-            write!(f, "{functor} {}", self.indented(member.as_ref()))?;
+            write!(
+                f,
+                "{}{functor}{SPACE}{}",
+                self.indent,
+                self.indented_with_offset(member.as_ref(), functor.len() + SPACE.len())
+            )?;
         }
         Ok(())
     }
 
+    const MIN_LINEBREAK_LEN: usize = 80;
+
     pub fn fmt_rel(&self, map: &Rel, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut buf = String::new();
+
+        // First try printing it inline.
+        self.fmt_rel_inline(map, &mut buf)?;
+
+        if buf.len() <= Self::MIN_LINEBREAK_LEN {
+            write!(f, "{}", buf)
+        } else {
+            // If line too long, split on to multiple lines.
+            self.fmt_rel_splitline(map, f)
+        }
+    }
+
+    pub fn fmt_rel_splitline(&self, map: &Rel, f: &mut impl fmt::Write) -> fmt::Result {
+        for (sym, tm) in map {
+            match (sym, tm.as_ref()) {
+                (s1, Tm::Sym(s2)) if s1 == s2 => {
+                    writeln!(f, "[{sym}]")?;
+                    // writeln!(f, "[{sym}")?;
+                    // write!(f, "{}]", self.indent.dedented())?;
+                }
+                (s, Tm::Var(v)) if s.to_str().to_pascal_case() == v.to_str().as_ref() => {
+                    writeln!(f, "[{v}]")?;
+                    // writeln!(f, "[{v}")?;
+                    // write!(f, "{}]", self.indent.dedented())?;
+                }
+                _ => {
+                    writeln!(f, "[{sym}")?;
+                    writeln!(f, "{}{}", self.indent, self.indented(tm))?;
+                    write!(f, "{}]", self.dedented().indent)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn fmt_rel_inline(&self, map: &Rel, f: &mut impl fmt::Write) -> fmt::Result {
         for (sym, tm) in map {
             match (sym, tm.as_ref()) {
                 (s1, Tm::Sym(s2)) if s1 == s2 => {
                     write!(f, "[{sym}]")?;
                 }
-                (s, Tm::Var(v))
-                    if s.to_str().eq_ignore_ascii_case(v.to_str().as_ref()) && v.is_original() =>
-                {
+                (s, Tm::Var(v)) if s.to_str().to_pascal_case() == v.to_str().as_ref() => {
                     write!(f, "[{v}]")?;
                 }
                 _ => write!(f, "[{sym} {}]", self.with_tm(tm.as_ref()))?,
@@ -86,82 +191,125 @@ impl<'tm> TmDisplayer<'tm> {
         Ok(())
     }
 
-    const MIN_LIST_LINEBREAK_LEN: usize = 6;
+    pub fn fmt_list(&self, x: RcTm, xs: RcTm, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut buf = String::new();
 
-    pub fn fmt_list(&self, mut x: RcTm, mut xs: RcTm, f: &mut fmt::Formatter) -> fmt::Result {
-        enum Layout {
-            Inline,
-            Block,
+        // First try printing it inline.
+        self.fmt_list_inline(x.clone(), xs.clone(), &mut buf)?;
+
+        if buf.len() <= Self::MIN_LINEBREAK_LEN {
+            write!(f, "{}", buf)
+        } else {
+            // If line too long, split on to multiple lines.
+            self.fmt_list_splitline(x, xs, f)
         }
+    }
 
-        struct Sep {
-            indent: usize,
-            layout: Layout,
-        }
-
-        impl Display for Sep {
-            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                match self.layout {
-                    Layout::Inline => write!(f, " "),
-                    Layout::Block => {
-                        writeln!(f)?;
-                        for _ in 0..self.indent {
-                            write!(f, "    ")?;
-                        }
-                        Ok(())
-                    }
-                }
-            }
-        }
-
-        impl Sep {
-            fn close_brace(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                if let Layout::Block = self.layout {
-                    writeln!(f)?;
-                    for _ in 0..self.indent - 1 {
-                        write!(f, "    ")?;
-                    }
-                }
-                write!(f, "}}")
-            }
-        }
-
-        let mut sep = Sep {
-            layout: Layout::Inline,
-            indent: self.indent + 1,
-        };
+    pub fn fmt_list_inline(
+        &self,
+        mut x: RcTm,
+        mut xs: RcTm,
+        f: &mut impl fmt::Write,
+    ) -> fmt::Result {
+        const SPACE: char = ' ';
 
         write!(f, "{{")?;
 
-        if let Some((rest, _tail)) = xs.try_as_list() {
-            if rest.len() >= Self::MIN_LIST_LINEBREAK_LEN {
-                sep.layout = Layout::Block;
-                write!(f, "{sep}")?;
-            }
-        }
-
         loop {
-            write!(f, "{}", self.indented(&*x))?;
+            write!(f, "{}", self.indented(&x))?;
 
-            match &*xs {
+            match xs.as_ref() {
                 // xs = {y ...{}} = {y}
                 Tm::Cons(y, ys) if matches!(**ys, Tm::Nil) => {
-                    write!(f, "{sep}{}", self.indented(&**y))?;
-                    return sep.close_brace(f);
+                    write!(f, " {}", self.indented(y))?;
+                    return write!(f, "}}");
                 }
                 // xs = {y ...ys} (continue loop)
                 Tm::Cons(y, ys) => (x, xs) = (y.clone(), ys.clone()),
                 // xs = {x}
-                Tm::Nil => return sep.close_brace(f),
+                Tm::Nil => return write!(f, "}}"),
+                // Malformed list like: {1 2 ...3} (instead of {1 2 3 ...{}})
+                xs => {
+                    write!(f, "{SPACE}{}{}", Tok::Spread, self.indented(xs))?;
+                    return write!(f, "}}");
+                }
+            }
+
+            write!(f, "{SPACE}")?;
+        }
+    }
+
+    pub fn fmt_list_splitline(
+        &self,
+        mut x: RcTm,
+        mut xs: RcTm,
+        f: &mut impl fmt::Write,
+    ) -> fmt::Result {
+        struct Sep(Indent);
+
+        impl fmt::Display for Sep {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                writeln!(f)?;
+                write!(f, "{}", self.0)?;
+                Ok(())
+            }
+        }
+
+        struct CloseBrace(Indent);
+
+        impl fmt::Display for CloseBrace {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                writeln!(f)?;
+                write!(f, "{}}}", self.0)?;
+                Ok(())
+            }
+        }
+
+        let sep = Sep(self.indent);
+        let close_brace = CloseBrace(self.indent.dedented());
+
+        write!(f, "{{{sep}")?;
+
+        loop {
+            write!(f, "{}", self.indented(&x))?;
+
+            match &*xs {
+                // xs = {y ...{}} = {y}
+                Tm::Cons(y, ys) if matches!(**ys, Tm::Nil) => {
+                    return write!(f, "{sep}{}{close_brace}", self.indented(y));
+                }
+                // xs = {y ...ys} (continue loop)
+                Tm::Cons(y, ys) => (x, xs) = (y.clone(), ys.clone()),
+                // xs = {x}
+                Tm::Nil => return write!(f, "{close_brace}"),
 
                 // Malformed list like: {1 2 ...3} (instead of {1 2 3 ...{}})
                 xs => {
-                    write!(f, "{sep}{}{}", Tok::Spread, self.indented(xs))?;
-                    return sep.close_brace(f);
+                    return write!(f, "{sep}{}{}{close_brace}", Tok::Spread, self.indented(xs));
                 }
             }
 
             write!(f, "{sep}")?;
+        }
+    }
+
+    fn fmt_txt(f: &mut Formatter<'_>, char_list: &char_list::CharList, tail: &RcTm) -> fmt::Result {
+        let mut char_list = char_list;
+        let mut tail = tail;
+
+        write!(f, "\"{char_list}")?;
+        while let Tm::Txt(cl, tl) = tail.as_ref() {
+            char_list = cl;
+            tail = tl;
+            write!(f, "{char_list}")?;
+        }
+
+        if let Tm::Nil = tail.as_ref() {
+            write!(f, "\"")
+        } else {
+            // If it's not text, and the tail wasn't Nil, break
+            // and display the tail (either Var or malformed).
+            write!(f, "[{} {tail}]\"", Tok::Spread)
         }
     }
 }
@@ -177,26 +325,8 @@ impl<'tm> fmt::Display for TmDisplayer<'tm> {
             Tm::Sym(s) => self.fmt_sym(f, s),
             Tm::Var(v) => write!(f, "{v}"),
             Tm::Int(i) => write!(f, "{i}"),
-            Tm::Txt(char_list, tail) => {
-                let mut char_list = char_list;
-                let mut tail = tail;
-
-                write!(f, "\"{char_list}")?;
-                while let Tm::Txt(cl, tl) = tail.as_ref() {
-                    char_list = cl;
-                    tail = tl;
-                    write!(f, "{char_list}")?;
-                }
-
-                if let Tm::Nil = tail.as_ref() {
-                    write!(f, "\"")
-                } else {
-                    // If it's not text, and the tail wasn't Nil, break
-                    // and display the tail (either Var or malformed).
-                    write!(f, "[{} {tail}]\"", Tok::Spread)
-                }
-            }
-            Tm::Block(functor, members) => self.fmt_block(functor, members, f),
+            Tm::Txt(char_list, tail) => Self::fmt_txt(f, char_list, tail),
+            Tm::Block(functor, members) => self.fmt_block(f, functor, members),
             Tm::Rel(map) => self.fmt_rel(map, f),
             Tm::Cons(x, xs) => self.fmt_list(x.clone(), xs.clone(), f),
             Tm::Nil => write!(f, "{{}}"),

--- a/librellog/src/data_structures.rs
+++ b/librellog/src/data_structures.rs
@@ -60,7 +60,7 @@ impl Deref for Var {
 impl fmt::Display for Var {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(gen) = self.gen {
-            write!(f, "{}_{}", self.istr, gen)
+            write!(f, "{}${}", self.istr, gen)
         } else {
             write!(f, "{}", self.istr)
         }

--- a/librellog/src/lex/lex.rs
+++ b/librellog/src/lex/lex.rs
@@ -84,6 +84,11 @@ fn text_literal<'i>(i: Span<'i>) -> Res<'i, CharList> {
     .parse(i)
 }
 
+pub fn matches_variable(src: &str) -> bool {
+    src.starts_with(|c: char| c.is_uppercase() || c == '_')
+        && src.chars().skip(1).all(|c| c.is_alphanumeric())
+}
+
 fn var_or_sym(i: Span) -> Res<Tok> {
     let quoted_sym = delimited(
         tag("'"),
@@ -99,10 +104,7 @@ fn var_or_sym(i: Span) -> Res<Tok> {
     )))
     .map(|span| span.fragment().into())
     .map(|sym: IStr| {
-        if sym
-            .to_str()
-            .starts_with(|c: char| c.is_uppercase() || c == '_')
-        {
+        if matches_variable(sym.to_str().as_ref()) {
             Tok::Var(sym.into())
         } else if sym.to_str().starts_with(char::is_lowercase) {
             Tok::Sym(sym)

--- a/librellog/src/rt/breakpoint.rs
+++ b/librellog/src/rt/breakpoint.rs
@@ -1,5 +1,52 @@
+use core::fmt;
+use std::str::FromStr;
+
 use super::Rt;
 
 pub trait Breakpoint {
-    fn breakpoint(&mut self, rt: &Rt, title: &str);
+    fn breakpoint(&mut self, rt: &Rt, title: Event);
+}
+
+/// See [Byrd Box Model](https://www.swi-prolog.org/pldoc/man?section=byrd-box-model)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Event {
+    Call,
+    Exit,
+    Redo,
+    Fail,
+    Exception,
+    Unify,
+}
+
+impl fmt::Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Event::Call => "call",
+                Event::Exit => "exit",
+                Event::Redo => "redo",
+                Event::Fail => "fail",
+                Event::Exception => "exception",
+                Event::Unify => "unify",
+            }
+        )
+    }
+}
+
+impl FromStr for Event {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "call" => Ok(Event::Call),
+            "exit" => Ok(Event::Exit),
+            "redo" => Ok(Event::Redo),
+            "fail" => Ok(Event::Fail),
+            "exception" => Ok(Event::Exception),
+            "unify" => Ok(Event::Unify),
+            _ => Err(()),
+        }
+    }
 }

--- a/librellog/src/rt/breakpoint.rs
+++ b/librellog/src/rt/breakpoint.rs
@@ -1,0 +1,5 @@
+use super::Rt;
+
+pub trait Breakpoint {
+    fn breakpoint(&mut self, rt: &Rt, title: &str);
+}

--- a/librellog/src/rt/mod.rs
+++ b/librellog/src/rt/mod.rs
@@ -1,5 +1,6 @@
 //! Defines the rellog runtime.
 
+pub mod breakpoint;
 mod err;
 pub mod intrinsics;
 pub mod kb;

--- a/librellog/src/rt/rt.rs
+++ b/librellog/src/rt/rt.rs
@@ -25,6 +25,7 @@ pub struct Rt {
     pub intrs: IntrinsicsMap,
     pub recursion_depth: Cell<usize>,
     pub max_recursion_depth: Cell<usize>,
+    pub debug_mode: Cell<bool>,
 }
 
 impl Rt {
@@ -34,6 +35,7 @@ impl Rt {
             intrs: IntrinsicsMap::initialize(),
             recursion_depth: 0.into(),
             max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH.into(),
+            debug_mode: false.into(),
         }
     }
 
@@ -61,6 +63,10 @@ impl Rt {
         'rtb: 'it,
         'td: 'it,
     {
+        if self.debug_mode.get() {
+            eprintln!("[depth:{}] Enter: `{query}`", self.recursion_depth.get());
+        }
+
         if self.recursion_depth.get() >= self.max_recursion_depth.get() {
             return Err::MaxRecursionDepthExceeded {
                 query: u.reify_term(&query),

--- a/repl/src/app_err.rs
+++ b/repl/src/app_err.rs
@@ -10,6 +10,7 @@ pub enum AppErr<'ts> {
     FileRead(String, std::io::Error),
     Lex(lex::LexError),
     Parse(parse::Error<'ts>),
+    IoError(Box<dyn std::error::Error>),
 }
 
 impl<'ts> From<lex::LexError> for AppErr<'ts> {
@@ -41,6 +42,7 @@ impl<'ts> fmt::Display for AppErr<'ts> {
             ),
             AppErr::Lex(le) => write!(f, "Unable to tokenize: {le}"),
             AppErr::Parse(pe) => write!(f, "Unable to parse: {pe}"),
+            AppErr::IoError(e) => write!(f, "An IO operation failed: {e}"),
         }
     }
 }

--- a/repl/src/debugger.rs
+++ b/repl/src/debugger.rs
@@ -1,51 +1,82 @@
-use std::{collections::BTreeSet, io::Write, ops::ControlFlow};
+use core::fmt;
+use std::{collections::BTreeSet, io::Write, ops::ControlFlow, str::FromStr};
 
 use librellog::{
-    ast::{RcTm, Sig, Tm},
-    lex::tok::Tok,
-    rt::{Rt, UnifierSet},
+    ast::{RcTm, Tm},
+    interner::IStr,
+    rt::{breakpoint::Event, Rt, UnifierSet},
 };
+use nu_ansi_term::Color;
 
+#[derive(Debug)]
 pub struct Debugger {
-    pub filters: BTreeSet<QueryFilter>,
+    pub watch_criteria: BTreeSet<WatchCriterion>,
 }
 
 impl Default for Debugger {
     fn default() -> Self {
-        use QueryFilter::*;
         Self {
-            filters: [Ignore(Box::new(AndBlocks)), Ignore(Box::new(OrBlocks))]
-                .into_iter()
-                .collect(),
+            watch_criteria: [WatchCriterion::Any].into_iter().collect(),
         }
     }
 }
 
 impl librellog::rt::breakpoint::Breakpoint for Debugger {
-    fn breakpoint(&mut self, rt: &Rt, title: &str) {
+    fn breakpoint(&mut self, rt: &Rt, event: Event) {
         if !rt.debug_mode.get() {
             return;
         }
 
         let query = rt.current_query();
 
-        if self.ignores(&query, title) {
+        if !self.matches_watch_criteria(&query, event) {
             return;
         }
 
         loop {
-            println!("[[breakpoint]]");
-            println!("[[depth:{:0>2}]]", rt.recursion_depth.get());
-            println!("[[event '{title}'][query]]");
-            println!("{query}");
+            let depth = rt.recursion_depth.get();
+            println!("[[breakpoint][event {event}][depth {depth}][query");
+            println!("  {}", Color::Yellow.paint(format!("{query}")));
+            println!("]]");
 
             print!("[[dbg]]-- ");
             std::io::stdout().flush().unwrap();
-            let mut cmd_buf = String::new();
-            let _ = std::io::stdin().read_line(&mut cmd_buf).unwrap();
+            let mut src_buf = String::new();
+            // let _ = std::io::stdin().read_line(&mut src_buf).unwrap();
+            let _ = std::io::stdin().read_line(&mut src_buf).unwrap();
             println!();
 
-            match self.interpret_cmd(rt, &cmd_buf) {
+            let mut tok_buf = Vec::new();
+            let ts = match librellog::lex::tokenize_into(
+                &mut tok_buf,
+                &src_buf[..],
+                "<debugger cmd input>".into(),
+            ) {
+                Ok(ts) => ts,
+                Err(_) if src_buf.trim().is_empty() => {
+                    // Step.
+                    println!("# Stepping...");
+                    break;
+                }
+                Err(e) => {
+                    println!("Command error: {e}");
+                    continue;
+                }
+            };
+            let cmd = match librellog::parse::entire_term(ts) {
+                Ok(tm) => tm,
+                Err(_) if src_buf.trim().is_empty() => {
+                    // Step.
+                    println!("# Stepping...");
+                    break;
+                }
+                Err(e) => {
+                    println!("Command error: {e}");
+                    continue;
+                }
+            };
+
+            match self.interpret_cmd(rt, cmd) {
                 ControlFlow::Break(()) => {
                     println!();
                     break;
@@ -56,23 +87,124 @@ impl librellog::rt::breakpoint::Breakpoint for Debugger {
     }
 }
 
+macro_rules! rel_match {
+    ($expr:expr, { $( $([$key:ident = $value:pat])+ $(| $([$key2:ident = $value2:ident])+)* => $block:expr, )* else => $default:expr }) => {
+        loop {
+            $(
+                $(
+                    let $key = $expr.get(&IStr::from(stringify!($key)));
+                )+
+                if let ( $(Some($value),)+ ) = ( $($key, )+ ) {
+                    break $block;
+                }
+
+                $(
+                    $(
+                        let $key2 = $expr.get(&IStr::from(stringify!($key2)));
+                    )+
+                    if let ( $(Some($value2),)+ ) = ( $($key2, )+ ) {
+                        break $block;
+                    }
+                )*
+            )*
+
+            break $default;
+        }
+    };
+}
+
 impl Debugger {
-    pub fn ignores(&self, query: &RcTm, title: &str) -> bool {
-        self.filters.iter().any(|qf| !qf.allows(query, title))
+    pub fn matches_watch_criteria(&self, query: &RcTm, event: Event) -> bool {
+        self.watch_criteria
+            .iter()
+            .all(|qf| qf.matches(query, event))
     }
 
-    fn interpret_cmd(&mut self, rt: &Rt, cmd: &str) -> ControlFlow<(), ()> {
-        let cmd = cmd.trim();
-        match cmd {
-            ":help" | "help" | "?" | ":h" | "-h" | "--help" => {
-                self.print_help();
-                ControlFlow::Continue(())
+    fn interpret_cmd(&mut self, rt: &Rt, cmd: RcTm) -> ControlFlow<(), ()> {
+        match cmd.as_ref() {
+            Tm::Sym(s) => match s.to_str().as_ref() {
+                "help" | "h" | "?" => {
+                    self.print_help();
+                    ControlFlow::Continue(())
+                }
+                "nodebug" | "nodbg" | "dbg" | "d" => {
+                    rt.debug_mode.set(false);
+                    ControlFlow::Break(())
+                }
+                "filters" | "f" | "watch_critera" | "wc" => {
+                    println!("# Current Watch Critera:");
+                    for (i, wc) in self.watch_criteria.iter().enumerate() {
+                        println!("    - {wc} #{}", i + 1);
+                    }
+                    println!();
+                    ControlFlow::Continue(())
+                }
+                "step" | "s" => {
+                    println!("[[step]]");
+                    ControlFlow::Break(())
+                }
+                _ => {
+                    println!("# Unknown debugger command: `{cmd}`");
+                    println!("# Type `help` to show debugger help.");
+                    println!();
+                    ControlFlow::Continue(())
+                }
+            },
+            Tm::Var(_) => {
+                self.watch_criteria.insert(WatchCriterion::Any);
+                ControlFlow::Break(())
             }
-            ":nodebug" | ":nodbg" | ":dbg" | ":d" => {
-                rt.debug_mode.set(false);
-                ControlFlow::Continue(())
-            }
-            "" | ":step" | ":s" => ControlFlow::Break(()),
+            Tm::Rel(rel) => rel_match!(
+                rel,
+                {
+                    [event = e_sym] | [e = e_sym] => {
+                        if let Some(e) = e_sym.try_as_sym().and_then(|e| Event::from_str(e.to_str().as_ref()).ok()) {
+                            self.watch_criteria.insert(WatchCriterion::Event(e, Box::new(WatchCriterion::Any)));
+                            ControlFlow::Break(())
+                        } else {
+                            println!("# Unknown debugger event: `{e_sym}`");
+                            println!("# Valid events are:");
+                            println!("#   - call");
+                            println!("#   - exit");
+                            println!("#   - redo");
+                            println!("#   - fail");
+                            println!("#   - exception");
+                            println!("#   - unify");
+                            println!();
+                            ControlFlow::Continue(())
+                        }
+                    },
+                    [watch = query_tm] | [w = query_tm] => {
+                        let wc = WatchCriterion::QueryTm(query_tm.clone());
+                        self.watch_criteria.insert(wc);
+                        ControlFlow::Break(())
+                    },
+                    [event = e_sym][watch = query_tm] | [e = e_sym][w = query_tm] => {
+                        if let Some(e) = e_sym.try_as_sym().and_then(|e| Event::from_str(e.to_str().as_ref()).ok()) {
+                            let q = WatchCriterion::QueryTm(query_tm.clone());
+                            self.watch_criteria.insert(WatchCriterion::Event(e, Box::new(q)));
+                            ControlFlow::Break(())
+                        } else {
+                            println!("# Unknown debugger event: `{e_sym}`");
+                            println!("# Valid events are:");
+                            println!("#   - call");
+                            println!("#   - exit");
+                            println!("#   - redo");
+                            println!("#   - fail");
+                            println!("#   - exception");
+                            println!("#   - unify");
+                            println!();
+                            ControlFlow::Continue(())
+                        }
+                    },
+                    else => {
+                        println!("# Unknown debugger command: `{cmd}`");
+                        println!("# Type `help` to show debugger help.");
+                        println!();
+                        ControlFlow::Continue(())
+                    }
+                }
+            ),
             _ => {
                 println!("# Unknown debugger command: `{cmd}`");
                 println!("# Type `help` to show debugger help.");
@@ -85,39 +217,52 @@ impl Debugger {
     fn print_help(&self) {
         println!("[[debugger_help]]");
         println!("{{");
-        println!("#  :help | :h | ?           Show debugger help.");
-        println!("#  :nodebug | :d | :nodbg   Quit debugger.");
-        println!("#  :step | <ENTER>          Advance to the goal to be solved.");
-        println!("#  :+ FILTER                Add a debug filter");
+        println!("#  :help | :h | ?             Show debugger help.");
+        println!("#  :nodebug | :d | :nodbg     Quit debugger.");
+        println!("#  :step | <ENTER>            Advance to the goal to be solved.");
+        println!("#  (:watch | :w) WATCH_CRIT   Add a watch criterion.");
         println!("#");
-        println!("#  FILTERS");
-        println!("#  todo!()");
+        println!("#  Watch Criteria");
+        println!("#  VAR | _             Matches any event.");
+        println!("#  [e EVENT]           Matches a specific event.");
+        println!("#  [w GOAL]            Matches a specific rellog goal (may contain vars).");
+        println!("#  [e EVENT][w GOAL]   Matches a specific term at a specific event.");
+        println!("#");
+        println!("#  Events");
+        println!("#  call        When a query is called.");
+        println!("#  exit        When a query exits successfully.");
+        println!("#  redo        When a query is called.");
+        println!("#  fail        When a query is called.");
+        println!("#  exception   When a query raises an exception.");
+        println!("#  unify       When a query head is unified.");
         println!("}}");
         println!();
     }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum QueryFilter {
-    Ignore(Box<QueryFilter>),
-    AndBlocks,
-    OrBlocks,
-    RelWithSig(Sig),
-    Title(String),
+pub enum WatchCriterion {
+    Any,
+    QueryTm(RcTm),
+    Event(Event, Box<WatchCriterion>),
 }
 
-impl QueryFilter {
-    pub fn allows(&self, query: &RcTm, title: &str) -> bool {
+impl WatchCriterion {
+    pub fn matches(&self, query: &RcTm, event: Event) -> bool {
         match self {
-            Self::Ignore(qf) => !qf.allows(query, title),
-            Self::AndBlocks => matches!(query.as_ref(), Tm::Block(Tok::Dash, _)),
-            Self::OrBlocks => matches!(query.as_ref(), Tm::Block(Tok::Pipe, _)),
-            Self::RelWithSig(sig) => {
-                let sig_tm = RcTm::from(sig.clone());
-                let u = UnifierSet::new();
-                u.unify(&sig_tm, query).is_some()
-            }
-            Self::Title(t) => title == t,
+            Self::Any => true,
+            Self::QueryTm(tm) => UnifierSet::new().unify(tm, query).is_some(),
+            Self::Event(e, wc) => *e == event && wc.matches(query, event),
+        }
+    }
+}
+
+impl fmt::Display for WatchCriterion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WatchCriterion::Any => write!(f, "Any"),
+            WatchCriterion::QueryTm(tm) => write!(f, "[w {tm}]"),
+            WatchCriterion::Event(e, tm) => write!(f, "[e {e}][w {tm}"),
         }
     }
 }

--- a/repl/src/debugger.rs
+++ b/repl/src/debugger.rs
@@ -48,6 +48,7 @@ impl librellog::rt::breakpoint::Breakpoint for Debugger {
                 Signal::CtrlC => {
                     println!("Exiting debugger...");
                     rt.debug_mode.set(false);
+                    self.line_editor.toggle_debug_mode();
                     return;
                 }
                 Signal::CtrlD => {
@@ -109,6 +110,7 @@ impl Debugger {
                 }
                 "nodebug" | "nodbg" | "dbg" | "d" => {
                     rt.debug_mode.set(false);
+                    self.line_editor.toggle_debug_mode();
                     ControlFlow::Break(())
                 }
                 "filters" | "f" | "watch_critera" | "wc" => {
@@ -145,11 +147,11 @@ impl Debugger {
                             println!("# Unknown debugger event: `{e_sym}`");
                             println!("# Valid events are:");
                             println!("#   - call");
-                            println!("#   - exit");
-                            println!("#   - redo");
-                            println!("#   - fail");
-                            println!("#   - exception");
-                            println!("#   - unify");
+                            println!("#   - exit      (TODO)");
+                            println!("#   - redo      (TODO)");
+                            println!("#   - fail      (TODO)");
+                            println!("#   - exception (TODO)");
+                            println!("#   - unify     (TODO");
                             println!();
                             ControlFlow::Continue(())
                         }
@@ -168,11 +170,11 @@ impl Debugger {
                             println!("# Unknown debugger event: `{e_sym}`");
                             println!("# Valid events are:");
                             println!("#   - call");
-                            println!("#   - exit");
-                            println!("#   - redo");
-                            println!("#   - fail");
-                            println!("#   - exception");
-                            println!("#   - unify");
+                            println!("#   - exit      (TODO)");
+                            println!("#   - redo      (TODO)");
+                            println!("#   - fail      (TODO)");
+                            println!("#   - exception (TODO)");
+                            println!("#   - unify     (TODO");
                             println!();
                             ControlFlow::Continue(())
                         }
@@ -195,27 +197,25 @@ impl Debugger {
     }
 
     fn print_help(&self) {
-        println!("[[debugger_help]]");
-        println!("{{");
-        println!("#  :help | :h | ?             Show debugger help.");
-        println!("#  :nodebug | :d | :nodbg     Quit debugger.");
-        println!("#  :step | <ENTER>            Advance to the goal to be solved.");
-        println!("#  (:watch | :w) WATCH_CRIT   Add a watch criterion.");
+        println!("# Debugger Help");
+        println!("#  help | h                Show debugger help.");
+        println!("#  nodebug | d | nodbg     Quit debugger.");
+        println!("#  step | <ENTER>          Advance to the goal to be solved.");
+        println!("#  (watch | w) WATCH_CRIT  Add a watch criterion.");
         println!("#");
-        println!("#  Watch Criteria");
+        println!("# Watch Criteria");
         println!("#  VAR | _             Matches any event.");
         println!("#  [e EVENT]           Matches a specific event.");
         println!("#  [w GOAL]            Matches a specific rellog goal (may contain vars).");
         println!("#  [e EVENT][w GOAL]   Matches a specific term at a specific event.");
         println!("#");
-        println!("#  Events");
+        println!("# Events");
         println!("#  call        When a query is called.");
         println!("#  exit        When a query exits successfully.");
         println!("#  redo        When a query is called.");
         println!("#  fail        When a query is called.");
         println!("#  exception   When a query raises an exception.");
         println!("#  unify       When a query head is unified.");
-        println!("}}");
         println!();
     }
 }

--- a/repl/src/debugger.rs
+++ b/repl/src/debugger.rs
@@ -1,0 +1,123 @@
+use std::{collections::BTreeSet, io::Write, ops::ControlFlow};
+
+use librellog::{
+    ast::{RcTm, Sig, Tm},
+    lex::tok::Tok,
+    rt::{Rt, UnifierSet},
+};
+
+pub struct Debugger {
+    pub filters: BTreeSet<QueryFilter>,
+}
+
+impl Default for Debugger {
+    fn default() -> Self {
+        use QueryFilter::*;
+        Self {
+            filters: [Ignore(Box::new(AndBlocks)), Ignore(Box::new(OrBlocks))]
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+impl librellog::rt::breakpoint::Breakpoint for Debugger {
+    fn breakpoint(&mut self, rt: &Rt, title: &str) {
+        if !rt.debug_mode.get() {
+            return;
+        }
+
+        let query = rt.current_query();
+
+        if self.ignores(&query, title) {
+            return;
+        }
+
+        loop {
+            println!("[[breakpoint]]");
+            println!("[[depth:{:0>2}]]", rt.recursion_depth.get());
+            println!("[[event '{title}'][query]]");
+            println!("{query}");
+
+            print!("[[dbg]]-- ");
+            std::io::stdout().flush().unwrap();
+            let mut cmd_buf = String::new();
+            let _ = std::io::stdin().read_line(&mut cmd_buf).unwrap();
+            println!();
+
+            match self.interpret_cmd(rt, &cmd_buf) {
+                ControlFlow::Break(()) => {
+                    println!();
+                    break;
+                }
+                ControlFlow::Continue(()) => continue,
+            }
+        }
+    }
+}
+
+impl Debugger {
+    pub fn ignores(&self, query: &RcTm, title: &str) -> bool {
+        self.filters.iter().any(|qf| !qf.allows(query, title))
+    }
+
+    fn interpret_cmd(&mut self, rt: &Rt, cmd: &str) -> ControlFlow<(), ()> {
+        let cmd = cmd.trim();
+        match cmd {
+            ":help" | "help" | "?" | ":h" | "-h" | "--help" => {
+                self.print_help();
+                ControlFlow::Continue(())
+            }
+            ":nodebug" | ":nodbg" | ":dbg" | ":d" => {
+                rt.debug_mode.set(false);
+                ControlFlow::Continue(())
+            }
+            "" | ":step" | ":s" => ControlFlow::Break(()),
+            _ => {
+                println!("# Unknown debugger command: `{cmd}`");
+                println!("# Type `help` to show debugger help.");
+                println!();
+                ControlFlow::Continue(())
+            }
+        }
+    }
+
+    fn print_help(&self) {
+        println!("[[debugger_help]]");
+        println!("{{");
+        println!("#  :help | :h | ?           Show debugger help.");
+        println!("#  :nodebug | :d | :nodbg   Quit debugger.");
+        println!("#  :step | <ENTER>          Advance to the goal to be solved.");
+        println!("#  :+ FILTER                Add a debug filter");
+        println!("#");
+        println!("#  FILTERS");
+        println!("#  todo!()");
+        println!("}}");
+        println!();
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum QueryFilter {
+    Ignore(Box<QueryFilter>),
+    AndBlocks,
+    OrBlocks,
+    RelWithSig(Sig),
+    Title(String),
+}
+
+impl QueryFilter {
+    pub fn allows(&self, query: &RcTm, title: &str) -> bool {
+        match self {
+            Self::Ignore(qf) => !qf.allows(query, title),
+            Self::AndBlocks => matches!(query.as_ref(), Tm::Block(Tok::Dash, _)),
+            Self::OrBlocks => matches!(query.as_ref(), Tm::Block(Tok::Pipe, _)),
+            Self::RelWithSig(sig) => {
+                let sig_tm = RcTm::from(sig.clone());
+                let u = UnifierSet::new();
+                u.unify(&sig_tm, query).is_some()
+            }
+            Self::Title(t) => title == t,
+        }
+    }
+}

--- a/repl/src/debugger.rs
+++ b/repl/src/debugger.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{collections::BTreeSet, ops::ControlFlow, str::FromStr, sync::Arc};
 
 use librellog::{
-    ast::{RcTm, Tm},
+    ast::{tm_displayer::TmDisplayer, RcTm, Tm},
     interner::IStr,
     rt::{breakpoint::Event, Rt, UnifierSet},
 };
@@ -39,8 +39,9 @@ impl librellog::rt::breakpoint::Breakpoint for Debugger {
 
         loop {
             let depth = rt.recursion_depth.get();
+            let query_disp = TmDisplayer::default().indented(query.as_ref());
             println!("[[breakpoint][event {event}][depth {depth}][query");
-            println!("  {}", Color::Yellow.paint(format!("{query}")));
+            println!("    {}", Color::Yellow.paint(format!("{query_disp}")));
             println!("]]");
 
             let src_buf = match self.line_editor.read_line().unwrap() {

--- a/repl/src/line_editor.rs
+++ b/repl/src/line_editor.rs
@@ -1,0 +1,30 @@
+use std::cell::RefCell;
+
+use reedline::{Reedline, Signal};
+
+use crate::line_editor_config::{RellogReplConfigHandle, ReplMode};
+
+pub struct LineEditor {
+    repl_config: RefCell<RellogReplConfigHandle>,
+    line_editor: RefCell<Reedline>,
+}
+
+impl LineEditor {
+    pub fn new() -> Self {
+        let repl_config = RellogReplConfigHandle::default();
+        let line_editor = RefCell::new(repl_config.create_editor());
+        Self {
+            line_editor,
+            repl_config: RefCell::new(repl_config),
+        }
+    }
+
+    pub fn set_repl_mode(&self, mode: ReplMode) {
+        self.repl_config.borrow_mut().set_repl_mode(mode);
+    }
+
+    pub fn read_line(&self) -> Result<Signal, impl std::error::Error> {
+        let dyn_prompt = self.repl_config.borrow();
+        self.line_editor.borrow_mut().read_line(&*dyn_prompt)
+    }
+}

--- a/repl/src/line_editor.rs
+++ b/repl/src/line_editor.rs
@@ -23,6 +23,10 @@ impl LineEditor {
         self.repl_config.borrow_mut().set_repl_mode(mode);
     }
 
+    pub fn toggle_debug_mode(&self) {
+        self.repl_config.borrow_mut().toggle_debug_mode();
+    }
+
     pub fn read_line(&self) -> Result<Signal, impl std::error::Error> {
         let dyn_prompt = self.repl_config.borrow();
         self.line_editor.borrow_mut().read_line(&*dyn_prompt)

--- a/repl/src/line_editor_config/mod.rs
+++ b/repl/src/line_editor_config/mod.rs
@@ -11,7 +11,7 @@ mod validator;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplMode {
-    TopLevel,
+    TopLevel { debug: bool },
     PrintingSolns,
 }
 
@@ -23,7 +23,7 @@ pub struct RellogReplConfig {
 impl Default for RellogReplConfig {
     fn default() -> Self {
         Self {
-            repl_mode: ReplMode::TopLevel,
+            repl_mode: ReplMode::TopLevel { debug: false },
             prompt_edit_mode: PromptEditMode::Vi(PromptViMode::Insert),
         }
     }

--- a/repl/src/line_editor_config/mod.rs
+++ b/repl/src/line_editor_config/mod.rs
@@ -12,7 +12,16 @@ mod validator;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplMode {
     TopLevel { debug: bool },
-    PrintingSolns,
+    PrintingSolns { debug: bool },
+}
+
+impl ReplMode {
+    pub fn toggle_debug(&mut self) {
+        match self {
+            ReplMode::TopLevel { debug } => *debug = !*debug,
+            ReplMode::PrintingSolns { debug } => *debug = !*debug,
+        }
+    }
 }
 
 pub struct RellogReplConfig {
@@ -64,6 +73,10 @@ impl RellogReplConfigHandle {
 
     pub fn set_repl_mode(&self, mode: ReplMode) {
         self.write().unwrap().repl_mode = mode;
+    }
+
+    pub fn toggle_debug_mode(&self) {
+        self.write().unwrap().repl_mode.toggle_debug();
     }
 
     fn read(

--- a/repl/src/line_editor_config/prompt.rs
+++ b/repl/src/line_editor_config/prompt.rs
@@ -13,14 +13,18 @@ impl Prompt for RellogReplConfigHandle {
         let cfg = self.read().unwrap();
 
         match &cfg.repl_mode {
-            ReplMode::TopLevel { .. } => match &cfg.prompt_edit_mode {
-                PromptEditMode::Default => "".into(),
-                PromptEditMode::Emacs => "(emacs)".into(),
-                PromptEditMode::Vi(PromptViMode::Insert) => "(vi:insert)".into(),
-                PromptEditMode::Vi(PromptViMode::Normal) => "(vi:normal)".into(),
-                PromptEditMode::Custom(c) => format!("({c})").into(),
-            },
-            ReplMode::PrintingSolns => "[ENTER to show next solution, CTRL-C to break]".into(),
+            ReplMode::TopLevel { .. } | ReplMode::PrintingSolns { debug: true } => {
+                match &cfg.prompt_edit_mode {
+                    PromptEditMode::Default => "".into(),
+                    PromptEditMode::Emacs => "(emacs)".into(),
+                    PromptEditMode::Vi(PromptViMode::Insert) => "(vi:insert)".into(),
+                    PromptEditMode::Vi(PromptViMode::Normal) => "(vi:normal)".into(),
+                    PromptEditMode::Custom(c) => format!("({c})").into(),
+                }
+            }
+            ReplMode::PrintingSolns { debug: false } => {
+                "[ENTER to show next solution, CTRL-C to break]".into()
+            }
         }
     }
 
@@ -28,9 +32,11 @@ impl Prompt for RellogReplConfigHandle {
         let mut cfg = self.write().unwrap();
         cfg.prompt_edit_mode = edit_mode;
         match &cfg.repl_mode {
-            ReplMode::TopLevel { debug } if !debug => "-- ".into(),
-            ReplMode::TopLevel { .. } => "[[debug]]\n-- ".into(),
-            ReplMode::PrintingSolns => "".into(),
+            ReplMode::TopLevel { debug: false } => "-- ".into(),
+            ReplMode::TopLevel { debug: true } | ReplMode::PrintingSolns { debug: true } => {
+                "[[debug]]\n-- ".into()
+            }
+            ReplMode::PrintingSolns { debug: false } => "".into(),
         }
     }
 

--- a/repl/src/line_editor_config/prompt.rs
+++ b/repl/src/line_editor_config/prompt.rs
@@ -13,7 +13,7 @@ impl Prompt for RellogReplConfigHandle {
         let cfg = self.read().unwrap();
 
         match &cfg.repl_mode {
-            ReplMode::TopLevel => match &cfg.prompt_edit_mode {
+            ReplMode::TopLevel { .. } => match &cfg.prompt_edit_mode {
                 PromptEditMode::Default => "".into(),
                 PromptEditMode::Emacs => "(emacs)".into(),
                 PromptEditMode::Vi(PromptViMode::Insert) => "(vi:insert)".into(),
@@ -28,7 +28,8 @@ impl Prompt for RellogReplConfigHandle {
         let mut cfg = self.write().unwrap();
         cfg.prompt_edit_mode = edit_mode;
         match &cfg.repl_mode {
-            ReplMode::TopLevel => "-- ".into(),
+            ReplMode::TopLevel { debug } if !debug => "-- ".into(),
+            ReplMode::TopLevel { .. } => "[[debug]]\n-- ".into(),
             ReplMode::PrintingSolns => "".into(),
         }
     }

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(unused_must_use)]
 
 mod app_err;
+mod debugger;
 mod line_editor_config;
 mod repl;
 

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app_err;
 mod debugger;
+mod line_editor;
 mod line_editor_config;
 mod repl;
 

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -229,6 +229,9 @@ impl Repl {
                     }
                     Err(e) => {
                         println!("{}", Color::Red.paint(format!("Exception: {e}")));
+                        for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
+                            println!("{}", Color::Red.paint(format!("# ^[depth:{i:0>2}]: `{q}`")));
+                        }
                         continue 'outer;
                     }
                 };
@@ -284,6 +287,18 @@ impl Repl {
                     "   - [false] {}",
                     Color::Yellow.paint("# No additional solutions found.")
                 );
+            }
+
+            if self.rt.debug_mode.get() {
+                for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
+                    println!(
+                        "{}",
+                        Color::Yellow.paint(format!(
+                            "# ^[depth:{i:0>2}]: `{}`",
+                            Color::LightYellow.paint(q.to_string())
+                        ))
+                    );
+                }
             }
         }
     }

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -116,10 +116,12 @@ impl Repl {
                     println!("  :load | :l        Load the source given source file.");
                     println!("  :reload | :r      Reloads the source file(s).");
                     println!("  :unload | :u      Unloads the given source file.");
+                    println!("  :debug | :d       Enters/exits debugging mode.");
                     println!("  [Builtins]        Show a list of builtin relations.");
                     println!("  [help Sig]        Show help text for a relation given by `Sig`.");
-                    println!("  :quit | :exit     Exit the repl.");
-                    println!("   | :q | :wq");
+                    println!("  :quit | :q |      Exit the repl.");
+                    println!("… :exit | :e |");
+                    println!("… :wq");
                     continue 'outer;
                 }
                 [":quit" | ":q" | ":exit" | ":wq"] => {

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -20,6 +20,7 @@ use reedline::{Reedline, Signal};
 
 use crate::{
     app_err::{AppErr, AppRes},
+    debugger::Debugger,
     line_editor_config::{RellogReplConfigHandle, ReplMode},
 };
 
@@ -38,7 +39,7 @@ impl Repl {
 
     pub fn new_loading_files(fnames: Vec<String>) -> Self {
         let kb = KnowledgeBase::default();
-        let rt = Rt::new(kb);
+        let rt = Rt::new(kb).with_debugger(Debugger::default());
         let config = RellogReplConfigHandle::default();
         let mut repl = Self {
             files_loaded: BTreeSet::new(),

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -2,11 +2,13 @@ use std::{
     cell::RefCell,
     collections::BTreeSet,
     io::{self, Read},
+    ops::ControlFlow,
     path::PathBuf,
+    sync::{Arc, Mutex},
 };
 
 use librellog::{
-    ast::{self, dup::TmDuplicator},
+    ast::{self, dup::TmDuplicator, RcTm},
     lex::{
         self,
         tok::{At, Tok},
@@ -16,20 +18,20 @@ use librellog::{
     utils::display_unifier_set::DisplayUnifierSet,
 };
 use nu_ansi_term::Color;
-use reedline::{Reedline, Signal};
+use reedline::Signal;
 
 use crate::{
     app_err::{AppErr, AppRes},
     debugger::Debugger,
-    line_editor_config::{RellogReplConfigHandle, ReplMode},
+    line_editor::LineEditor,
+    line_editor_config::ReplMode,
 };
 
 pub struct Repl {
+    rt: Rt,
+    line_editor: Arc<LineEditor>,
     files_loaded: BTreeSet<String>,
     files_failed_to_load: BTreeSet<String>,
-    config: RellogReplConfigHandle,
-    line_editor: Reedline,
-    rt: Rt,
 }
 
 impl Repl {
@@ -38,15 +40,14 @@ impl Repl {
     }
 
     pub fn new_loading_files(fnames: Vec<String>) -> Self {
+        let line_editor = Arc::new(LineEditor::new());
         let kb = KnowledgeBase::default();
-        let rt = Rt::new(kb).with_debugger(Debugger::default());
-        let config = RellogReplConfigHandle::default();
+        let rt = Rt::new(kb).with_debugger(Debugger::new(line_editor.clone()));
         let mut repl = Self {
+            rt,
+            line_editor,
             files_loaded: BTreeSet::new(),
             files_failed_to_load: BTreeSet::new(),
-            line_editor: config.create_editor(),
-            config,
-            rt,
         };
 
         let mut tok_buf = Vec::new();
@@ -96,9 +97,9 @@ impl Repl {
 
         'outer: loop {
             let debug = self.rt.debug_mode.get();
-            self.config.set_repl_mode(ReplMode::TopLevel { debug });
+            self.line_editor.set_repl_mode(ReplMode::TopLevel { debug });
 
-            let query_buf = match self.line_editor.read_line(&self.config) {
+            let query_buf = match self.line_editor.read_line() {
                 Ok(Signal::Success(s)) => s,
                 Ok(Signal::CtrlC | Signal::CtrlD) => break 'outer,
                 Err(e) => {
@@ -112,17 +113,7 @@ impl Repl {
 
             match query_parts[..] {
                 ["help" | ":help" | ":h" | "?"] => {
-                    println!("Enter a RELLOG TERM or one of these REPL COMMANDS:");
-                    println!("  :help | :h | ?    Displays this help text.");
-                    println!("  :load | :l        Load the source given source file.");
-                    println!("  :reload | :r      Reloads the source file(s).");
-                    println!("  :unload | :u      Unloads the given source file.");
-                    println!("  :debug | :d       Enters/exits debugging mode.");
-                    println!("  [Builtins]        Show a list of builtin relations.");
-                    println!("  [help Sig]        Show help text for a relation given by `Sig`.");
-                    println!("  :quit | :q |      Exit the repl.");
-                    println!("… :exit | :e |");
-                    println!("… :wq");
+                    print_help();
                     continue 'outer;
                 }
                 [":quit" | ":q" | ":exit" | ":wq"] => {
@@ -191,117 +182,112 @@ impl Repl {
                 _ => {}
             }
 
-            let mut buf = Vec::new();
-            let tokens = match lex::tokenize_into(&mut buf, &query_buf[..], "<user input>".into()) {
-                Ok(ts) => ts,
-                Err(le) => {
-                    println!("{}", Color::Red.paint(format!("Tokenization error: {le}")));
-                    continue 'outer;
-                }
+            let query = match parse_term(&query_buf[..]) {
+                Some(value) => value,
+                None => continue 'outer,
             };
 
-            let mut no_solns_yet_found = true;
-
-            let query = match parse::entire_term(tokens) {
-                Ok(q) => q,
-                Err(e) => {
-                    println!("Parse error: {e}");
-                    continue 'outer;
-                }
-            };
-
-            let u = UnifierSet::new();
-            let td = RefCell::new(TmDuplicator::default());
-            let mut solns = self.rt.solve_query(query, u, &td);
-            let mut or_bar_printed = false;
-
-            self.config.set_repl_mode(ReplMode::PrintingSolns);
-
-            while let Some(soln) = solns.next() {
-                let soln = match soln {
-                    Ok(soln) => {
-                        let disp = DisplayUnifierSet {
-                            u: soln.clone(),
-                            display_or_bar: or_bar_printed,
-                        };
-                        print!("{disp}");
-                        no_solns_yet_found = false;
-                        soln
-                    }
-                    Err(e) => {
-                        println!("{}", Color::Red.paint(format!("Exception: {e}")));
-                        for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
-                            println!("{}", Color::Red.paint(format!("# ^[depth:{i:0>2}]: `{q}`")));
-                        }
-                        continue 'outer;
-                    }
-                };
-
-                // If we *know* there are no more solutions...
-                match solns.size_hint() {
-                    (_, Some(0)) if soln.is_empty() => {
-                        let msg = Color::Yellow.paint("# The query holds unconditionally.");
-                        println!(" {msg}");
-                        continue 'outer;
-                    }
-                    (_, Some(0)) => {
-                        let msg = Color::Yellow.paint("# Exactly 1 solution found.");
-                        println!(" {msg}");
-                        continue 'outer;
-                    }
-                    (lo, Some(hi)) if lo == hi => {
-                        let msg = Color::Yellow.paint(format!("# {lo} solution(s) remain."));
-                        println!(" {msg}");
-                    }
-                    (_, Some(hi)) => {
-                        let msg =
-                            Color::Yellow.paint(format!("# At most {hi} solution(s) remain."));
-                        println!(" {msg}");
-                    }
-                    _ => {}
-                }
-
-                match self.line_editor.read_line(&self.config).unwrap() {
-                    Signal::Success(_) => {}
-                    Signal::CtrlC => {
-                        println!("...");
-                        continue 'outer;
-                    }
-                    Signal::CtrlD => break 'outer,
-                }
-
-                print!("\n|"); // Print an "or"; more solns incoming.
-                or_bar_printed = true;
-            }
-
-            if !or_bar_printed {
-                print!(" ");
-            }
-
-            if no_solns_yet_found {
-                println!(
-                    "   - [false] {}",
-                    Color::Yellow.paint("# The query has no solutions.")
-                );
-            } else {
-                println!(
-                    "   - [false] {}",
-                    Color::Yellow.paint("# No additional solutions found.")
-                );
-            }
-
-            if self.rt.debug_mode.get() {
-                for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
-                    println!(
-                        "{}",
-                        Color::Yellow.paint(format!(
-                            "# ^[depth:{i:0>2}]: `{}`",
-                            Color::LightYellow.paint(q.to_string())
-                        ))
-                    );
-                }
+            match self.solve_and_display_solns(query) {
+                ControlFlow::Continue(_) => continue 'outer,
+                ControlFlow::Break(_) => break 'outer,
             }
         }
+    }
+
+    fn solve_and_display_solns(&mut self, query: RcTm) -> ControlFlow<(), ()> {
+        let mut no_solns_yet_found = true;
+        let u = UnifierSet::new();
+        let td = RefCell::new(TmDuplicator::default());
+        let mut solns = self.rt.solve_query(query, u, &td);
+        let mut or_bar_printed = false;
+
+        self.line_editor.set_repl_mode(ReplMode::PrintingSolns);
+
+        while let Some(soln) = solns.next() {
+            let soln = match soln {
+                Ok(soln) => {
+                    let disp = DisplayUnifierSet {
+                        u: soln.clone(),
+                        display_or_bar: or_bar_printed,
+                    };
+                    print!("{disp}");
+                    no_solns_yet_found = false;
+                    soln
+                }
+                Err(e) => {
+                    println!("{}", Color::Red.paint(format!("Exception: {e}")));
+                    for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
+                        println!("{}", Color::Red.paint(format!("# ^[depth:{i:0>2}]: `{q}`")));
+                    }
+                    return ControlFlow::Continue(());
+                }
+            };
+
+            // If we *know* there are no more solutions...
+            match solns.size_hint() {
+                (_, Some(0)) if soln.is_empty() => {
+                    let msg = Color::Yellow.paint("# The query holds unconditionally.");
+                    println!(" {msg}");
+                    return ControlFlow::Continue(());
+                }
+                (_, Some(0)) => {
+                    let msg = Color::Yellow.paint("# Exactly 1 solution found.");
+                    println!(" {msg}");
+                    return ControlFlow::Continue(());
+                }
+                (lo, Some(hi)) if lo == hi => {
+                    let msg = Color::Yellow.paint(format!("# {lo} solution(s) remain."));
+                    println!(" {msg}");
+                }
+                (_, Some(hi)) => {
+                    let msg = Color::Yellow.paint(format!("# At most {hi} solution(s) remain."));
+                    println!(" {msg}");
+                }
+                _ => {}
+            }
+
+            match self.line_editor.read_line().unwrap() {
+                Signal::Success(_) => {}
+                Signal::CtrlC => {
+                    println!("...");
+                    return ControlFlow::Continue(());
+                }
+                Signal::CtrlD => return ControlFlow::Break(()),
+            }
+
+            print!("\n|"); // Print an "or"; more solns incoming.
+            or_bar_printed = true;
+        }
+
+        if !or_bar_printed {
+            print!(" ");
+        }
+
+        if no_solns_yet_found {
+            println!(
+                "   - [false] {}",
+                Color::Yellow.paint("# The query has no solutions.")
+            );
+        } else {
+            println!(
+                "   - [false] {}",
+                Color::Yellow.paint("# No additional solutions found.")
+            );
+        }
+
+        if self.rt.debug_mode.get() {
+            for (i, q) in self.rt.query_stack.borrow().iter().enumerate().rev() {
+                println!(
+                    "{}",
+                    Color::Yellow.paint(format!(
+                        "# ^[depth:{i:0>2}]: `{}`",
+                        Color::LightYellow.paint(q.to_string())
+                    ))
+                );
+            }
+        }
+
+        ControlFlow::Continue(())
     }
 
     fn reload(&mut self, tok_buf: &mut Vec<At<Tok>>) {
@@ -317,6 +303,39 @@ impl Repl {
             let _ = self.load_file(tok_buf, fname);
         }
     }
+}
+
+fn print_help() {
+    println!("Enter a RELLOG TERM or one of these REPL COMMANDS:");
+    println!("  :help | :h | ?    Displays this help text.");
+    println!("  :load | :l        Load the source given source file.");
+    println!("  :reload | :r      Reloads the source file(s).");
+    println!("  :unload | :u      Unloads the given source file.");
+    println!("  :debug | :d       Enters/exits debugging mode.");
+    println!("  [Builtins]        Show a list of builtin relations.");
+    println!("  [help Sig]        Show help text for a relation given by `Sig`.");
+    println!("  :quit | :q |      Exit the repl.");
+    println!("… :exit | :e |");
+    println!("… :wq");
+}
+
+fn parse_term(src: &str) -> Option<RcTm> {
+    let mut buf = Vec::new();
+    let tokens = match lex::tokenize_into(&mut buf, src, "<user input>".into()) {
+        Ok(ts) => ts,
+        Err(le) => {
+            println!("{}", Color::Red.paint(format!("Tokenization error: {le}")));
+            return None;
+        }
+    };
+    let query = match parse::entire_term(tokens) {
+        Ok(q) => q,
+        Err(e) => {
+            println!("Parse error: {e}");
+            return None;
+        }
+    };
+    Some(query)
 }
 
 fn load_module_from_file(tok_buf: &mut Vec<At<Tok>>, fname: String) -> AppRes<ast::Module> {

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -94,7 +94,9 @@ impl Repl {
         let mut tok_buf = Vec::new();
 
         'outer: loop {
-            self.config.set_repl_mode(ReplMode::TopLevel);
+            let debug = self.rt.debug_mode.get();
+            self.config.set_repl_mode(ReplMode::TopLevel { debug });
+
             let query_buf = match self.line_editor.read_line(&self.config) {
                 Ok(Signal::Success(s)) => s,
                 Ok(Signal::CtrlC | Signal::CtrlD) => break 'outer,
@@ -123,6 +125,16 @@ impl Repl {
                 [":quit" | ":q" | ":exit" | ":wq"] => {
                     println!("Exiting Rellog REPL...");
                     break 'outer;
+                }
+                [":debug" | ":d"] => {
+                    let new_mode = !self.rt.debug_mode.get();
+                    self.rt.debug_mode.set(new_mode);
+                    if new_mode {
+                        println!("{}", Color::Yellow.paint("# Entering debug mode."));
+                    } else {
+                        println!("{}", Color::Yellow.paint("# Exiting debug mode."));
+                    }
+                    continue 'outer;
                 }
                 [":reload" | ":r"] => {
                     self.reload(&mut tok_buf);

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -4,7 +4,7 @@ use std::{
     io::{self, Read},
     ops::ControlFlow,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use librellog::{
@@ -201,7 +201,9 @@ impl Repl {
         let mut solns = self.rt.solve_query(query, u, &td);
         let mut or_bar_printed = false;
 
-        self.line_editor.set_repl_mode(ReplMode::PrintingSolns);
+        let debug = self.rt.debug_mode.get();
+        self.line_editor
+            .set_repl_mode(ReplMode::PrintingSolns { debug });
 
         while let Some(soln) = solns.next() {
             let soln = match soln {


### PR DESCRIPTION
More could be done, but this is a pretty good start.

Use `:d` in the repl to enter debug mode. Allows stepping through evaluation steps and rudimentary filters to skip irrelevant steps.