### PR TITLE
Repl-src-var-clash-fix

### DIFF
--- a/librellog/src/data_structures.rs
+++ b/librellog/src/data_structures.rs
@@ -1,4 +1,4 @@
-use std::{fmt, num::NonZeroUsize, ops::Deref};
+use std::{fmt, ops::Deref};
 
 use num::BigInt;
 use rpds::RedBlackTreeMap;
@@ -15,37 +15,74 @@ pub type Map<K, V> = RedBlackTreeMap<K, V>;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Var {
     istr: IStr,
-    gen: Option<NonZeroUsize>,
+    gen: Generation,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Generation {
+    /// Represents a var parsed from user input at the repl.
+    Repl,
+    /// Represents a var parsed from a source file.
+    Source,
+    /// Represents a var that has been duplicated already. An internal variable.
+    Internal(u16),
+}
+
+impl Generation {
+    pub fn bump(&self, new: u16) -> Self {
+        match self {
+            Self::Repl => Self::Internal(new),
+            Self::Source => Self::Internal(new),
+            Self::Internal(old) if new > *old => Self::Internal(new),
+            Self::Internal(old) => {
+                panic!("Attempting to set a generation to an older one! (old={old}, new={new})")
+            }
+        }
+    }
 }
 
 impl Var {
-    pub(crate) fn with_gen(&self, gen: NonZeroUsize) -> Self {
+    pub fn from_repl(s: impl Into<IStr>) -> Self {
         Self {
-            istr: self.istr,
-            gen: Some(gen),
+            istr: s.into(),
+            gen: Generation::Repl,
         }
     }
 
-    pub(crate) fn is_original(&self) -> bool {
-        self.gen.is_none()
+    pub fn from_source(s: impl Into<IStr>) -> Self {
+        Self {
+            istr: s.into(),
+            gen: Generation::Source,
+        }
+    }
+
+    pub fn with_gen(&self, gen: u16) -> Self {
+        Self {
+            istr: self.istr,
+            gen: Generation::Internal(gen),
+        }
+    }
+
+    pub fn gen(&self) -> Generation {
+        self.gen
+    }
+
+    pub fn gen_mut(&mut self) -> &mut Generation {
+        &mut self.gen
+    }
+
+    pub fn istr(&self) -> IStr {
+        self.istr
+    }
+
+    pub fn is_original(&self) -> bool {
+        matches!(self.gen, Generation::Repl) // Either rename the method or think about Generation::Source.
     }
 }
 
 impl Dup for Var {
     fn dup(&self, duper: &mut TmDuplicator) -> Self {
         duper.dup_var(self)
-    }
-}
-
-impl From<&str> for Var {
-    fn from(s: &str) -> Self {
-        IStr::from(s).into()
-    }
-}
-
-impl From<IStr> for Var {
-    fn from(istr: IStr) -> Self {
-        Self { istr, gen: None }
     }
 }
 
@@ -59,10 +96,10 @@ impl Deref for Var {
 
 impl fmt::Display for Var {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(gen) = self.gen {
-            write!(f, "{}${}", self.istr, gen)
-        } else {
-            write!(f, "{}", self.istr)
+        match self.gen {
+            Generation::Repl => write!(f, "{}", self.istr),
+            Generation::Source => write!(f, "{}$", self.istr),
+            Generation::Internal(gen) => write!(f, "{}${}", self.istr, gen),
         }
     }
 }

--- a/librellog/src/lex/lex.rs
+++ b/librellog/src/lex/lex.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, path::PathBuf, str::FromStr};
 
 use crate::{
-    data_structures::Int,
+    data_structures::{Int, Var},
     interner::IStr,
     lex::tok::{At, MakeAt, Tok},
     utils::my_nom::{Res, Span},
@@ -105,7 +105,7 @@ fn var_or_sym(i: Span) -> Res<Tok> {
     .map(|span| span.fragment().into())
     .map(|sym: IStr| {
         if matches_variable(sym.to_str().as_ref()) {
-            Tok::Var(sym.into())
+            Tok::Var(Var::from_source(sym))
         } else if sym.to_str().starts_with(char::is_lowercase) {
             Tok::Sym(sym)
         } else {
@@ -221,8 +221,13 @@ pub fn tokenize_into<'i, 'buf>(
 mod block_tests {
     use super::tokenize;
     use super::Tok::*;
+    use crate::data_structures::Var;
     use crate::lex::tok::At;
     use pretty_assertions::assert_eq;
+
+    fn src_var(s: &str) -> Var {
+        Var::from_source(s)
+    }
 
     #[test]
     fn tokenize_basic_relation_def() {
@@ -244,7 +249,7 @@ mod block_tests {
 
         let expected = vec![
             OBrack,
-            Var("A".into()),
+            Var(src_var("A")),
             CBrack,
             Dash,
             OBrack,
@@ -276,9 +281,9 @@ mod block_tests {
         let expected = vec![
             OBrack,
             Sym("asdf".into()),
-            Var("Qwerty".into()),
+            Var(src_var("Qwerty")),
             COBrack,
-            Var("Poiu".into()),
+            Var(src_var("Poiu")),
             CBrack,
         ];
 

--- a/librellog/src/rt/kb.rs
+++ b/librellog/src/rt/kb.rs
@@ -40,8 +40,7 @@ impl KnowledgeBase {
         self.relations.append(&mut other.relations);
     }
 
-    /// Returns an `ExactSizeIterator` of all the clauses that could match the given Rel.
-    /// Eventually this ought to perform smart argument-indexing.
+    /// Returns an `ExactSizeIterator` of all the clauses whose heads match the given query.
     /// If the relation does not exist, `None` is returned.
     pub fn index_match<'m>(
         &'m self,

--- a/librellog/src/rt/kb.rs
+++ b/librellog/src/rt/kb.rs
@@ -47,19 +47,24 @@ impl KnowledgeBase {
         &'m self,
         query_head: &Rel,
         u: &UnifierSet,
+        debug: bool,
     ) -> Option<impl ExactSizeIterator<Item = &'m Clause> + 'm> {
         let sig = query_head.keys().cloned().collect();
         let sig_based_index = self.relations.get(&sig)?;
-        println!(
-            "\nSIG_BASED_INDEX: {} ~ {}",
-            RcTm::from(query_head.clone()),
-            RcTm::list_from_iter(
-                sig_based_index
-                    .iter()
-                    .cloned()
-                    .map(|clause| RcTm::from(clause.head))
-            )
-        );
+
+        if debug {
+            println!(
+                "\nSIG_BASED_INDEX: {} ~ {}",
+                RcTm::from(query_head.clone()),
+                RcTm::list_from_iter(
+                    sig_based_index
+                        .iter()
+                        .cloned()
+                        .map(|clause| RcTm::from(clause.head))
+                )
+            );
+        }
+
         let arg_indexed = sig_based_index
             .iter()
             .filter(|clause| {
@@ -69,10 +74,12 @@ impl KnowledgeBase {
             })
             .collect::<Vec<_>>();
 
-        println!(
-            "ARG_INDEXED: {}",
-            RcTm::list_from_iter(arg_indexed.iter().map(|clause| clause.head.clone().into()))
-        );
+        if debug {
+            println!(
+                "ARG_INDEXED: {}",
+                RcTm::list_from_iter(arg_indexed.iter().map(|clause| clause.head.clone().into()))
+            );
+        }
 
         Some(arg_indexed.into_iter())
     }

--- a/librellog/src/rt/rt.rs
+++ b/librellog/src/rt/rt.rs
@@ -182,7 +182,7 @@ impl Rt {
         };
 
         // Perform "argument indexing", get all potientially-matching clauses.
-        let clauses = match self.db.index_match(rel) {
+        let clauses = match self.db.index_match(rel, &u) {
             Some(clauses) => clauses,
             None => {
                 // If it can't be found in the loaded module, check the intrinsics.

--- a/librellog/src/rt/rt.rs
+++ b/librellog/src/rt/rt.rs
@@ -182,7 +182,7 @@ impl Rt {
         };
 
         // Perform "argument indexing", get all potientially-matching clauses.
-        let clauses = match self.db.index_match(rel, &u) {
+        let clauses = match self.db.index_match(rel, &u, self.debug_mode.get()) {
             Some(clauses) => clauses,
             None => {
                 // If it can't be found in the loaded module, check the intrinsics.
@@ -291,7 +291,7 @@ impl Rt {
 
 #[test]
 fn test_runtime() {
-    use crate::{lex, parse};
+    use crate::{data_structures::Var, lex, parse};
     crate::init_interner();
 
     let src = "
@@ -316,6 +316,6 @@ fn test_runtime() {
         .collect::<Vec<_>>();
 
     assert2::let_assert!([Ok(u)] = &solns[..]);
-    let answer_var = Tm::Var("Compound".into()).into();
+    let answer_var = Tm::Var(Var::from_repl("Compound")).into();
     assert2::check!(&u.reify_term(&answer_var).to_string() == "{1 2 3 4 5 6}");
 }

--- a/librellog/src/std/elementwise.rellog
+++ b/librellog/src/std/elementwise.rellog
@@ -94,8 +94,6 @@
     - [rel Goal][Attrs]
     - [splatted Attrs][Unsplatted][ListsSplatted]
     - [attrs Unsplatted][rel GoalNew]
-    - [dbg [GoalNew]]
-    - [dbg [ListsSplatted]]
     - [ListsSplatted][goal GoalNew]
 
 
@@ -110,7 +108,6 @@
 
 [Goal][lists_splatted {[list {}][var A] [list {}][var B]}]
 [Goal][lists_splatted {[list {X ..Xs}][var A] [list {Y ..Ys}][var B]}]
-    - [dbg {X Y}]
     - [original {A B Goal}][duplicate {X Y GoalDup}]
     - GoalDup
     - [Goal][lists_splatted {[list Xs][var A] [list Ys][var B]}]
@@ -119,7 +116,7 @@
 
 [splatted {}][unsplatted {}][lists_splatted {}]
 
-[splatted {Attr0..Attrs0}][unsplatted {Attr..Attrs}][lists_splatted {[var IterationVar][List]..Xs}]
+[splatted {Attr0..Attrs0}][unsplatted {Attr..Attrs}][lists_splatted {[var IterationVar][List] ..Xs}]
     - [attr Attr0][Key][value [splat List]]
     - [Attr][Key][value IterationVar]
     - [splatted Attrs0][unsplatted Attrs][lists_splatted Xs]

--- a/librellog/src/std/elementwise.rellog
+++ b/librellog/src/std/elementwise.rellog
@@ -44,6 +44,32 @@
           - [gt @Numbers][lt @Bounds]
           - [member @Numbers][list {3 6 9}]
       ][Filtered]
+
+    {
+        [list {1 2 3}][var IterationVar$3]
+        [list X][var IterationVar$5]
+    }
+
+    {
+        [pred 1][succ X0]
+        [pred 2][succ X1]
+        [pred 3][succ X2]
+    }
+
+    {
+        {
+            [ele 1][var IterationVar$3]
+            [ele X0][var IterationVar$5]
+        }
+        {
+            [ele 2][var IterationVar$3]
+            [ele X1][var IterationVar$5]
+        }
+        {
+            [ele 3][var IterationVar$3]
+            [ele X2][var IterationVar$5]
+        }
+    }
     """
 ]]
 
@@ -68,8 +94,27 @@
     - [rel Goal][Attrs]
     - [splatted Attrs][Unsplatted][ListsSplatted]
     - [attrs Unsplatted][rel GoalNew]
-    - [dbg [goal GoalNew]]
+    - [dbg [GoalNew]]
     - [dbg [ListsSplatted]]
+    - [ListsSplatted][goal GoalNew]
+
+
+[Goal][lists_splatted {}]
+
+[Goal][lists_splatted {[list {}][Var]}]
+[Goal][lists_splatted {[list {X ..Xs}][Var]}]
+    - [original Goal][duplicate GoalDup][renaming {Var}][renamed {VarDup}]
+    - VarDup = X
+    - GoalDup
+    - [lists_splatted {[list Xs][Var]}][Goal]
+
+[Goal][lists_splatted {[list {}][var A] [list {}][var B]}]
+[Goal][lists_splatted {[list {X ..Xs}][var A] [list {Y ..Ys}][var B]}]
+    - [dbg {X Y}]
+    - [original {A B Goal}][duplicate {X Y GoalDup}]
+    - GoalDup
+    - [Goal][lists_splatted {[list Xs][var A] [list Ys][var B]}]
+
 
 
 [splatted {}][unsplatted {}][lists_splatted {}]

--- a/repl/src/debugger.rs
+++ b/repl/src/debugger.rs
@@ -40,8 +40,12 @@ impl librellog::rt::breakpoint::Breakpoint for Debugger {
         loop {
             let depth = rt.recursion_depth.get();
             let query_disp = TmDisplayer::default().indented(query.as_ref());
-            println!("[[breakpoint][event {event}][depth {depth}][query");
-            println!("    {}", Color::Yellow.paint(format!("{query_disp}")));
+            println!(
+                "[[breakpoint][event {event}][depth {depth}][query",
+                event = Color::Magenta.paint(event.to_string()),
+                depth = Color::Cyan.paint(depth.to_string()),
+            );
+            println!("    {}", Color::Yellow.paint(query_disp.to_string()));
             println!("]]");
 
             let src_buf = match self.line_editor.read_line().unwrap() {

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -337,7 +337,7 @@ fn parse_term(src: &str) -> Option<RcTm> {
             return None;
         }
     };
-    Some(query)
+    Some(query.source_vars_to_repl_vars())
 }
 
 fn load_module_from_file(tok_buf: &mut Vec<At<Tok>>, fname: String) -> AppRes<ast::Module> {


### PR DESCRIPTION
Fix a variable name clashing issue:

```
[...][...]
    [Goal][lists_splatted {[list {X ..Xs}][var A] [list {Y ..Ys}][var B]}]

...

-- [elementwise [pred [splat {1 2 3}]][succ [splat X]]]
```

The `X`'s clashed, but now it's fixed.